### PR TITLE
Restore overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 *.gem
 Gemfile.lock
 .bundle
+
+# doc
 .yardoc
+doc/
+
 vendor
+
+# don't include generated files
 lib/mimemagic/path.rb

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 .bundle
 .yardoc
 vendor
+lib/mimemagic/path.rb

--- a/.yardopts
+++ b/.yardopts
@@ -1,2 +1,6 @@
+--markup-provider=redcarpet
+--markup=markdown
 --no-private
 - README.md
+- LICENSE
+- CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ None
 ### Fixed
 
 None
+## 0.4.3
+
+* Improve the development/test experience (@coldnebo, @kachick)
+
+* Ensure the gem works in environments with gem caching (@haines)
+
+* Add support for MacPorts installed dependencies (@brlanier)
+
+* Allow using a dummy XML file in cases where the gem is just a transient
+  dependency. (@Scharrels)
+
 
 ## 0.4.2
 
@@ -40,6 +51,17 @@ to avoid conflicting with other dependencies in people's applications.
 ## 0.4.0
 
 Yanked release.
+
+## 0.3.10
+
+* Improve the development/test experience (@coldnebo, @kachick)
+
+* Ensure the gem works in environments with gem caching (@haines)
+
+* Add support for MacPorts installed dependencies (@brlanier)
+
+* Allow using a dummy XML file in cases where the gem is just a transient
+  dependency. (@Scharrels)
 
 ## 0.3.9 (2021-03-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Breaking Changes
 
+## 0.4.1
+
+Remove `mimemagic/overlay` as it contains outdated, little used, data.
+
 ## 0.3.7 (2021-03-25)
 
 You will now need to ensure you have a copy of the fd.o shared MIME
@@ -17,6 +21,13 @@ None
 ### Fixed
 
 None
+
+## 0.4.1
+
+
+## 0.4.0
+
+Yanked release.
 
 ## 0.3.7 (2021-03-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,40 @@ None
 
 None
 
+## 0.4.2
+
+* Resolve issues parsing the version of freedesktop.org.xml shipped with
+  Ubuntu Trusty.
+
+* Make Rake a runtime dependency.
+
+* Fix the test suite.
+
+* Relax the dependency on Nokogiri to something less specific in order
+to avoid conflicting with other dependencies in people's applications.
+
 ## 0.4.1
 
 
 ## 0.4.0
 
 Yanked release.
+
+## 0.3.9 (2021-03-25)
+
+* Resolve issues parsing the version of freedesktop.org.xml shipped with
+  Ubuntu Trusty.
+
+* Reintroduce overlays, since it seems at least some people were using
+  them.
+  
+* Make Rake a runtime dependency.
+
+* Fix the test suite.
+## 0.3.8 (2021-03-25)
+
+Relax the dependency on Nokogiri to something less specific in order
+to avoid conflicting with other dependencies in people's applications.
 
 ## 0.3.7 (2021-03-25)
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org/'
 gemspec
 
+gem 'yard'
+gem 'redcarpet'
+gem 'github-markup'

--- a/README.md
+++ b/README.md
@@ -48,9 +48,6 @@ Tests
 
 ```console
 $ bundle install
-$ cd ext/mimemagic/
-$ bundle exec rake
-$ popd
 
 $ bundle exec rake test
 ```
@@ -65,4 +62,4 @@ Authors
 LICENSE
 =======
 
-MIT
+{file:LICENSE MIT}

--- a/README.md
+++ b/README.md
@@ -46,10 +46,13 @@ http://www.rubydoc.info/github/mimemagicrb/mimemagic
 Tests
 =====
 
-```
-bundle install
+```console
+$ bundle install
+$ cd ext/mimemagic/
+$ bundle exec rake
+$ popd
 
-rake test
+$ bundle exec rake test
 ```
 
 Authors

--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@ provided by freedesktop.org (see http://freedesktop.org/wiki/Software/shared-mim
 
 [![Gem Version](https://img.shields.io/gem/v/mimemagic.svg)](http://rubygems.org/gems/mimemagic)
 
-*Warning:* If you are using a version of MimeMagic < 0.3.7, or version 0.4.0, you may well be in breach of the
-GPL due to a GPL licensed dependency that was bundled with this gem. You should update to a version >= 0.3.7 
-as soon as possible. See https://github.com/minad/mimemagic/issues/97 for details.
-
 Dependencies
 ============
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ rake test
 Authors
 =======
 
-Daniel Mendler
-Jon Wood
-[MimeMagic Contributors](https://github.com/mimemagicrb/mimemagic/graphs/contributors)
+* Daniel Mendler
+* Jon Wood
+* [MimeMagic Contributors](https://github.com/mimemagicrb/mimemagic/graphs/contributors)
 
 LICENSE
 =======

--- a/README.md
+++ b/README.md
@@ -36,7 +36,18 @@ MimeMagic.by_magic(File.open('test.html'))
 # etc...
 ```
 
-You can add your own magic with `MimeMagic.add`.
+Extra magic overlay
+=====
+
+Microsoft Office 2007+ formats (xlsx, docx, and pptx) are not supported by the mime database at freedesktop.org. These files are all zipped collections of xml files and will be detected as "application/zip". Mimemagic comes with extra magic you can overlay on top of the defaults to correctly detect these file types. Enable it like this:
+
+```ruby
+require 'mimemagic'
+require 'mimemagic/overlay'
+MimeMagic.by_magic(File.open('test.xlsx'))
+```
+
+You can add your own magic with `MimeMagic.add`. See `lib/mimemagic/overlay.rb`.
 
 API
 ===

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,15 @@
 require 'rake/testtask'
+require 'rake/clean'
+
+namespace :ext do
+  load 'ext/mimemagic/Rakefile'
+end
+CLOBBER.include("lib/mimemagic/path.rb")
 
 task :default => %w(test)
 
 desc 'Run tests with minitest'
-Rake::TestTask.new do |t|
+Rake::TestTask.new("test" => "ext:default") do |t|
   t.libs << 'test'
   t.pattern = 'test/*_test.rb'
 end

--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -23,7 +23,11 @@ end
 desc "Build a file pointing at the database"
 task :default do
   mime_database_path = locate_mime_database
-  open("../../lib/mimemagic/path.rb", "w") do |f|
+
+  target_dir = "#{ENV.fetch("RUBYARCHDIR")}/mimemagic"
+  mkdir_p target_dir
+
+  open("#{target_dir}/path.rb", "w") do |f|
     f.print(%Q{
       class MimeMagic
         DATABASE_PATH="#{mime_database_path}"

--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -23,11 +23,13 @@ end
 desc "Build a file pointing at the database"
 task :default do
   mime_database_path = locate_mime_database
-  open("../../lib/mimemagic/path.rb", "w") do |f|
-    f.print(%Q{
+  path_rb = File.expand_path("../../../lib/mimemagic/path.rb", __FILE__)
+  open(path_rb, "w") do |f|
+    f.print(<<~SOURCE
       class MimeMagic
         DATABASE_PATH="#{mime_database_path}"
       end
-    })
+      SOURCE
+    )
   end
 end

--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -24,7 +24,7 @@ end
 desc "Build a file pointing at the database"
 task :default do
   mime_database_path = locate_mime_database
-  target_dir = "#{ENV.fetch("RUBYARCHDIR")}/mimemagic"
+  target_dir = "#{ENV.fetch("RUBYARCHDIR", "../lib")}/mimemagic"
   mkdir_p target_dir
 
   open("#{target_dir}/path.rb", "w") do |f|

--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -6,6 +6,7 @@ def locate_mime_database
     (File.expand_path(ENV["FREEDESKTOP_MIME_TYPES_PATH"]) if ENV["FREEDESKTOP_MIME_TYPES_PATH"]),
     "/usr/local/share/mime/packages/freedesktop.org.xml",
     "/opt/homebrew/share/mime/packages/freedesktop.org.xml",
+    "/opt/local/share/mime/packages/freedesktop.org.xml",
     "/usr/share/mime/packages/freedesktop.org.xml"
   ].compact
   path = possible_paths.find { |candidate| File.exist?(candidate) }

--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -11,7 +11,7 @@ def locate_mime_database
   path = possible_paths.find { |candidate| File.exist?(candidate) }
 
   return path unless path.nil?
-  raise(<<~ERROR)
+  raise(<<-ERROR.gsub(/^ {3}/, ""))
    Could not find MIME type database in the following locations: #{possible_paths}
 
    Ensure you have either installed the shared-mime-info package for your distribution, or

--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -9,13 +9,13 @@ def locate_mime_database
     "/usr/share/mime/packages/freedesktop.org.xml"
   ].compact
   path = possible_paths.find { |candidate| File.exist?(candidate) }
-  
+
   return path unless path.nil?
   raise(<<~ERROR)
    Could not find MIME type database in the following locations: #{possible_paths}
-   
-   Ensure you have either installed the shared-mime-types package for your distribution, or 
-   obtain a version of freedesktop.org.xml and set FREEDESKTOP_MIME_TYPES_PATH to the location 
+
+   Ensure you have either installed the shared-mime-info package for your distribution, or
+   obtain a version of freedesktop.org.xml and set FREEDESKTOP_MIME_TYPES_PATH to the location
    of that file.
   ERROR
 end

--- a/lib/mimemagic/overlay.rb
+++ b/lib/mimemagic/overlay.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# Extra magic
+
+[['application/vnd.openxmlformats-officedocument.presentationml.presentation', [[0, "PK\003\004", [[0..5000, '[Content_Types].xml', [[0..5000, 'ppt/']]]]]]],
+ ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', [[0, "PK\003\004", [[0..5000, '[Content_Types].xml', [[0..5000, 'xl/']]]]]]],
+ ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', [[0, "PK\003\004", [[0..5000, '[Content_Types].xml', [[0..5000, 'word/']]]]]]]].each do |magic|
+  MimeMagic.add(magic[0], magic: magic[1])
+end

--- a/lib/mimemagic/tables.rb
+++ b/lib/mimemagic/tables.rb
@@ -26,7 +26,16 @@ class MimeMagic
         offset = offset.size == 2 ? offset[0]..offset[1] : offset[0]
         case type
         when 'string'
-          value.gsub!(/\\(x[\dA-Fa-f]{1,2}|0\d{1,3}|\d{1,3}|.)/) { eval("\"\\#{$1}\"") }
+          # This *one* pattern match, in the entirety of fd.o's mime types blows up the parser
+          # because of the escape character \c, so right here we have a hideous hack to
+          # accommodate that.
+          if value == '\chapter'
+            '\chapter'
+          else
+            value.gsub!(/\\(x[\dA-Fa-f]{1,2}|0\d{1,3}|\d{1,3}|.)/) {
+              eval("\"\\#{$1}\"")
+            }
+          end
         when 'big16'
           value = str2int(value)
           value = ((value >> 8).chr + (value & 0xFF).chr)

--- a/lib/mimemagic/version.rb
+++ b/lib/mimemagic/version.rb
@@ -1,5 +1,5 @@
 class MimeMagic
   # MimeMagic version string
   # @api public
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/lib/mimemagic/version.rb
+++ b/lib/mimemagic/version.rb
@@ -1,5 +1,5 @@
 class MimeMagic
   # MimeMagic version string
   # @api public
-  VERSION = '0.4.2'
+  VERSION = '0.4.3'
 end

--- a/lib/mimemagic/version.rb
+++ b/lib/mimemagic/version.rb
@@ -1,5 +1,5 @@
 class MimeMagic
   # MimeMagic version string
   # @api public
-  VERSION = '0.3.7'
+  VERSION = '0.4.1'
 end

--- a/mimemagic.gemspec
+++ b/mimemagic.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.extensions = %w(ext/mimemagic/Rakefile)
 
   s.summary = 'Fast mime detection by extension or content'
-  s.description = 'Fast mime detection by extension or content in pure ruby (Uses freedesktop.org.xml shared-mime-info database)'
+  s.description = 'Fast mime detection by extension or content (Uses freedesktop.org.xml shared-mime-info database)'
   s.homepage = 'https://github.com/mimemagicrb/mimemagic'
   s.license = 'MIT'
 

--- a/mimemagic.gemspec
+++ b/mimemagic.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency('nokogiri', '~> 1.11.2')
+  s.add_dependency('rake')
 
   s.add_development_dependency('minitest', '~> 5.14')
-  s.add_development_dependency('rake', '~> 13.0')
 
   if s.respond_to?(:metadata)
     s.metadata['changelog_uri'] = "https://github.com/mimemagicrb/mimemagic/blob/master/CHANGELOG.md"

--- a/mimemagic.gemspec
+++ b/mimemagic.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/mimemagicrb/mimemagic'
   s.license = 'MIT'
 
-  s.add_dependency('nokogiri', '~> 1.11.2')
+  s.add_dependency('nokogiri', '~> 1')
   s.add_dependency('rake')
 
   s.add_development_dependency('minitest', '~> 5.14')

--- a/test/files/text.x-tex
+++ b/test/files/text.x-tex
@@ -1,0 +1,46 @@
+\documentclass[12pt]{article}
+\usepackage{lingmacros}
+\usepackage{tree-dvips}
+\begin{document}
+
+\section*{Notes for My Paper}
+
+Don't forget to include examples of topicalization.
+They look like this:
+
+{\small
+\enumsentence{Topicalization from sentential subject:\\ 
+\shortex{7}{a John$_i$ [a & kltukl & [el & 
+  {\bf l-}oltoir & er & ngii$_i$ & a Mary]]}
+{ & {\bf R-}clear & {\sc comp} & 
+  {\bf IR}.{\sc 3s}-love   & P & him & }
+{John, (it's) clear that Mary loves (him).}}
+}
+
+\subsection*{How to handle topicalization}
+
+I'll just assume a tree structure like (\ex{1}).
+
+{\small
+\enumsentence{Structure of A$'$ Projections:\\ [2ex]
+\begin{tabular}[t]{cccc}
+    & \node{i}{CP}\\ [2ex]
+    \node{ii}{Spec} &   &\node{iii}{C$'$}\\ [2ex]
+        &\node{iv}{C} & & \node{v}{SAgrP}
+\end{tabular}
+\nodeconnect{i}{ii}
+\nodeconnect{i}{iii}
+\nodeconnect{iii}{iv}
+\nodeconnect{iii}{v}
+}
+}
+
+\subsection*{Mood}
+
+Mood changes when there is a topic, as well as when
+there is WH-movement.  \emph{Irrealis} is the mood when
+there is a non-subject topic or WH-phrase in Comp.
+\emph{Realis} is the mood when there is a subject topic
+or WH-phrase.
+
+\end{document}

--- a/test/mimemagic_test.rb
+++ b/test/mimemagic_test.rb
@@ -52,28 +52,20 @@ class TestMimeMagic < Minitest::Test
   end
 
   def test_recognize_extensions
-    assert true
-
-    # Unknown if this test failure is expected. Commenting out for now.
-    #
-    # assert_equal 'text/html', MimeMagic.by_extension('.html').to_s
-    # assert_equal 'text/html', MimeMagic.by_extension('html').to_s
-    # assert_equal 'text/html', MimeMagic.by_extension(:html).to_s
-    # assert_equal 'application/x-ruby', MimeMagic.by_extension('rb').to_s
-    # assert_nil MimeMagic.by_extension('crazy')
-    # assert_nil MimeMagic.by_extension('')
+    assert_equal 'text/html', MimeMagic.by_extension('.html').to_s
+    assert_equal 'text/html', MimeMagic.by_extension('html').to_s
+    assert_equal 'text/html', MimeMagic.by_extension(:html).to_s
+    assert_equal 'application/x-ruby', MimeMagic.by_extension('rb').to_s
+    assert_nil MimeMagic.by_extension('crazy')
+    assert_nil MimeMagic.by_extension('')
   end
 
   def test_recognize_by_a_path
-    assert true
-
-    # Unknown if this test failure is expected. Commenting out for now.
-    #
-    # assert_equal 'text/html', MimeMagic.by_path('/adsjkfa/kajsdfkadsf/kajsdfjasdf.html').to_s
-    # assert_equal 'text/html', MimeMagic.by_path('something.html').to_s
-    # assert_equal 'application/x-ruby', MimeMagic.by_path('wtf.rb').to_s
-    # assert_nil MimeMagic.by_path('where/am.html/crazy')
-    # assert_nil MimeMagic.by_path('')
+    assert_equal 'text/html', MimeMagic.by_path('/adsjkfa/kajsdfkadsf/kajsdfjasdf.html').to_s
+    assert_equal 'text/html', MimeMagic.by_path('something.html').to_s
+    assert_equal 'application/x-ruby', MimeMagic.by_path('wtf.rb').to_s
+    assert_nil MimeMagic.by_path('where/am.html/crazy')
+    assert_nil MimeMagic.by_path('')
   end
 
   def test_recognize_xlsx_as_zip_without_magic
@@ -86,27 +78,19 @@ class TestMimeMagic < Minitest::Test
   end
 
   def test_recognize_by_magic
-    assert true
-
-    # Unknown if this test failure is expected. Commenting out for now.
-    #
-    # Dir['test/files/*'].each do |file|
-    #   mime = file[11..-1].sub('.', '/').sub(/\{\w+\}/, '')
-    #   assert_equal mime, MimeMagic.by_magic(File.read(file)).to_s
-    #   assert_equal mime, MimeMagic.by_magic(File.open(file, 'rb')).to_s
-    # end
+    Dir['test/files/*'].each do |file|
+      mime = file[11..-1].sub('.', '/').sub(/\{\w+\}/, '')
+      assert_equal mime, MimeMagic.by_magic(File.read(file)).to_s
+      assert_equal mime, MimeMagic.by_magic(File.open(file, 'rb')).to_s
+    end
   end
 
   def test_recognize_all_by_magic
-    assert true
-
-    # Unknown if this test failure is expected. Commenting out for now.
-    #
-    # %w(msoffice rubyxl gdocs).each do |variant|
-    #   file = "test/files/application.vnd.openxmlformats-officedocument.spreadsheetml{#{variant}}.sheet"
-    #   mimes = %w[application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/zip]
-    #   assert_equal mimes, MimeMagic.all_by_magic(File.read(file)).map(&:type)
-    # end
+    %w(msoffice rubyxl gdocs).each do |variant|
+      file = "test/files/application.vnd.openxmlformats-officedocument.spreadsheetml{#{variant}}.sheet"
+      mimes = %w[application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/zip]
+      assert_equal mimes, MimeMagic.all_by_magic(File.read(file)).map(&:type)
+    end
   end
 
   def test_have_add

--- a/test/mimemagic_test.rb
+++ b/test/mimemagic_test.rb
@@ -78,6 +78,7 @@ class TestMimeMagic < Minitest::Test
   end
 
   def test_recognize_by_magic
+    load "mimemagic/overlay.rb"
     Dir['test/files/*'].each do |file|
       mime = file[11..-1].sub('.', '/').sub(/\{\w+\}/, '')
       assert_equal mime, MimeMagic.by_magic(File.read(file)).to_s
@@ -86,6 +87,7 @@ class TestMimeMagic < Minitest::Test
   end
 
   def test_recognize_all_by_magic
+    load 'mimemagic/overlay.rb'
     %w(msoffice rubyxl gdocs).each do |variant|
       file = "test/files/application.vnd.openxmlformats-officedocument.spreadsheetml{#{variant}}.sheet"
       mimes = %w[application/vnd.openxmlformats-officedocument.spreadsheetml.sheet application/zip]

--- a/test/mimemagic_test.rb
+++ b/test/mimemagic_test.rb
@@ -52,17 +52,17 @@ class TestMimeMagic < Minitest::Test
   end
 
   def test_recognize_extensions
-    assert_equal 'text/html', MimeMagic.by_extension('.html').to_s
-    assert_equal 'text/html', MimeMagic.by_extension('html').to_s
-    assert_equal 'text/html', MimeMagic.by_extension(:html).to_s
+    assert_equal 'application/xhtml+xml', MimeMagic.by_extension('.html').to_s
+    assert_equal 'application/xhtml+xml', MimeMagic.by_extension('html').to_s
+    assert_equal 'application/xhtml+xml', MimeMagic.by_extension(:html).to_s
     assert_equal 'application/x-ruby', MimeMagic.by_extension('rb').to_s
     assert_nil MimeMagic.by_extension('crazy')
     assert_nil MimeMagic.by_extension('')
   end
 
   def test_recognize_by_a_path
-    assert_equal 'text/html', MimeMagic.by_path('/adsjkfa/kajsdfkadsf/kajsdfjasdf.html').to_s
-    assert_equal 'text/html', MimeMagic.by_path('something.html').to_s
+    assert_equal 'application/xhtml+xml', MimeMagic.by_path('/adsjkfa/kajsdfkadsf/kajsdfjasdf.html').to_s
+    assert_equal 'application/xhtml+xml', MimeMagic.by_path('something.html').to_s
     assert_equal 'application/x-ruby', MimeMagic.by_path('wtf.rb').to_s
     assert_nil MimeMagic.by_path('where/am.html/crazy')
     assert_nil MimeMagic.by_path('')


### PR DESCRIPTION
This pull requests does a couple of things:

- Restore mime-type specific tests that were commented out
- Restore the file `lib/mimemagic/overlay.rb` to its original version from the 0.3.x series. This does two things:
  * Make the tests for Office 2007+ file types pass
  * Make dependent gems that use this file not fail to load (e.g., caxlsx)
- Update tests for recognizing `*.html` files; due to a change in the mime type database these are now recognized as `application/xhtml+xml`.